### PR TITLE
Lucene/Solr Version 7.7.1 fixiert

### DIFF
--- a/config/solrconfig.xml
+++ b/config/solrconfig.xml
@@ -2,7 +2,7 @@
 
 <config>
 
-    <luceneMatchVersion>7.0</luceneMatchVersion>
+  <luceneMatchVersion>7.7.1</luceneMatchVersion>
 
   <lib dir="${solr.install.dir:../../..}/contrib/extraction/lib" />
   <lib dir="${solr.install.dir:../../..}/dist" regex="solr-cell-\d.*\.jar" />


### PR DESCRIPTION
Wenn ich die Installationsdatei `install-solr.sh` im 4.6.4-Branch der Application richtig lese, dann installieren wir Solr in Version 7.7.1. Dann sollte auch die gleiche Lucene-Version angezogen werden, um Inkompatibilitäten auszuschließen. Daher im Element `luceneMatchVersion` die Versionsnummer angepasst.